### PR TITLE
Increase media query max-width

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -182,7 +182,7 @@ p {
 
 /* Responsive */
 
-@media screen and (max-width: 1450px) {
+@media screen and (max-width: 1460px) {
   main {
     grid-template-columns: 1.5fr 3fr 100px;
     grid-template-rows: 75px 250px repeat(3, 1fr) 50px;


### PR DESCRIPTION
There may be a better way to fix this so feel free to ignore but I thought I'd throw up a quick PR in case this is helpful.

No idea how I found this but the title breaks and overlaps the content in one specific case running Chrome on Windows 10 and only when the Chrome window is 880px high (it doesn't do this with the responsive mode in dev tools).

![image](https://user-images.githubusercontent.com/12234879/115072363-801c0d00-9ec5-11eb-855e-71f3b4e4e2c1.png)

Between 1451px and 1460px the title looks like this so I bumped the media query up to `max-width: 1460px`.

Pure frigging coincidence that I had my browser open at a size that broke the title while visiting the link :)

Everything else seems to look and respond in roughly the same way but now the title doesn't overlap in this one weird edge case.