### PR TITLE
Issue(1): Added debounced resize event to navbar

### DIFF
--- a/components/AppNav.vue
+++ b/components/AppNav.vue
@@ -46,8 +46,24 @@ export default {
       }
     }
   },
+  methods: {
+    debounce(func, timeout = 175) {
+      let timer;
+      return (...args) => {
+        clearTimeout(timer);
+        timer = setTimeout(() => { func.apply(this, args); }, timeout);
+      };
+    },
+    setMatchMedia() {
+      this.matchMedia = window.matchMedia("(max-width: 900px)").matches;
+    }
+  },
   mounted() {
-    this.matchMedia = window.matchMedia("(max-width: 900px)").matches;
+    this.setMatchMedia()
+    window.addEventListener("resize", this.debounce(this.setMatchMedia));
+  },
+  unmounted() {
+    window.removeEventListener("resize", this.debounce(this.setMatchMedia));
   }
 };
 </script>


### PR DESCRIPTION
@sdras As mentioned in your comment to issue 1, the intention is fairly barebones.

When the component is mounted on either side of 900px the click functionality works, so I added a listener for changes in size to re-apply your matchMedia check which (if I understood the issue correctly) solves for the problem outlined in issue 1.

There is a subtle delay when resizing, on account of the denounce (175ms) can be avoided by simply removing the debounce method, if needed.